### PR TITLE
ftp更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+upload.sh
+.DS_Store


### PR DESCRIPTION
.gitignoreファイルを追加して、upload.shがgithubのリポジトリに更新されないようにしました。upload.shファイルは個別にお送りします。同ディレクトリにおいて、
`ftp -n <  upload.sh`
を実行すると、index.html, format/*, img/*, を更新します。